### PR TITLE
Improve documentation for Linux installation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 *.exe
 *.py[cod]
+.envrc
 __pycache__/
-output_*
 outline
+output_*

--- a/README.md
+++ b/README.md
@@ -1,28 +1,36 @@
 # mariadb_pdf
 
 ## Installation
+
 - install [python](https://www.python.org/downloads/) `(3.10+)`
 - install [wkhtmltopdf](https://wkhtmltopdf.org/downloads.html) (if on windows copy wkhtmltopdf.exe to this directory)
-- Install python packages with (pip/pip3)
+- Install python packages with (pip/pip3):
     - toml
     - pdfkit
     - requests
     - bs4
 
+If you are on Linux (not tested on MacOS or Windows), you can setup a virtual
+environment with the following commands (needs `virtualenv`):
+
+```console
+virtualenv .venv
+source .venv/bin/activate
+pip3 install -r requirements.txt
+```
+
 ##  Usage
 
-- make sure
-[mariadb_kb_server](https://github.com/icerath/mariadb_kb_server)
+- make sure [mariadb_kb_server](https://github.com/icerath/mariadb_kb_server)
 is running.
 - run `'(python/python3) main.py'`
 
-
-
 ## Dependencies
-- python 3.10 +
-- wkhtmltopdf
+
+See [requirements.txt](./requirements.txt).
 
 ### Libraries
+
 - toml
 - pdfkit
 - requests

--- a/config.toml
+++ b/config.toml
@@ -1,5 +1,5 @@
 [TOC] 
-main_font_size = "12px"
+main_font_size = "13px"
 main_indent = "1em"
 main_margin = "0.5em"
 

--- a/config.toml
+++ b/config.toml
@@ -1,6 +1,6 @@
-[TOC] 
+[TOC]
 main_font_size = "13px"
-main_indent = "1em"
+main_indent = "0.8em"
 main_margin = "0.5em"
 
 chapter_font_size = "18px"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+bs4
+pdfkit
+requests
+toml


### PR DESCRIPTION
For installation, it's recommended to use python virtualenvironments on Linux.
The size of the font for the TOC needed increase to fix a bad alignment that seems to happen only on Linux.